### PR TITLE
Adapted for clang-3.6

### DIFF
--- a/src_clang/ClangCheck.cpp
+++ b/src_clang/ClangCheck.cpp
@@ -146,10 +146,7 @@ public:
 
 class InsertAdjuster : public clang::tooling::ArgumentsAdjuster {
 public:
-  enum Position {
-    BEGIN,
-    END
-  };
+  enum Position { BEGIN, END };
 
   InsertAdjuster(const CommandLineArguments &Extra, Position Pos)
       : Extra(Extra), Pos(Pos) {}
@@ -185,14 +182,14 @@ private:
 namespace clang_check {
 class ClangCheckActionFactory {
 public:
-  clang::ASTConsumer *newASTConsumer() {
+  std::unique_ptr<clang::ASTConsumer> newASTConsumer() {
     if (ASTList)
       return clang::CreateASTDeclNodeLister();
     if (ASTDump)
-      return clang::CreateASTDumper(ASTDumpFilter);
+      return clang::CreateASTDumper(ASTDumpFilter, true, true);
     if (ASTPrint)
       return clang::CreateASTPrinter(&llvm::outs(), ASTDumpFilter);
-    return new clang::ASTConsumer();
+    return std::unique_ptr<clang::ASTConsumer>(new clang::ASTConsumer());
   }
 };
 }

--- a/src_clang/matchers_rewriter.cpp
+++ b/src_clang/matchers_rewriter.cpp
@@ -111,10 +111,10 @@ public:
         .write(llvm::outs());
   }
 
-  ASTConsumer *CreateASTConsumer(CompilerInstance &CI,
-                                 StringRef file) override {
+  std::unique_ptr<clang::ASTConsumer>
+  CreateASTConsumer(CompilerInstance &CI, StringRef file) override {
     TheRewriter.setSourceMgr(CI.getSourceManager(), CI.getLangOpts());
-    return new MyASTConsumer(TheRewriter);
+    return std::unique_ptr<clang::ASTConsumer>(new MyASTConsumer(TheRewriter));
   }
 
 private:

--- a/src_clang/plugin_print_funcnames.cpp
+++ b/src_clang/plugin_print_funcnames.cpp
@@ -35,8 +35,9 @@ public:
 
 class PrintFunctionNamesAction : public PluginASTAction {
 protected:
-  ASTConsumer *CreateASTConsumer(CompilerInstance &CI, llvm::StringRef) {
-    return new PrintFunctionsConsumer();
+  std::unique_ptr<clang::ASTConsumer> CreateASTConsumer(CompilerInstance &CI,
+                                                        llvm::StringRef) {
+    return std::unique_ptr<clang::ASTConsumer>(new PrintFunctionsConsumer());
   }
 
   bool ParseArgs(const CompilerInstance &CI,

--- a/src_clang/tooling_sample.cpp
+++ b/src_clang/tooling_sample.cpp
@@ -120,11 +120,11 @@ public:
     TheRewriter.getEditBuffer(SM.getMainFileID()).write(llvm::outs());
   }
 
-  ASTConsumer *CreateASTConsumer(CompilerInstance &CI,
-                                 StringRef file) override {
+  std::unique_ptr<clang::ASTConsumer>
+  CreateASTConsumer(CompilerInstance &CI, StringRef file) override {
     llvm::errs() << "** Creating AST consumer for: " << file << "\n";
     TheRewriter.setSourceMgr(CI.getSourceManager(), CI.getLangOpts());
-    return new MyASTConsumer(TheRewriter);
+    return std::unique_ptr<clang::ASTConsumer>(new MyASTConsumer(TheRewriter));
   }
 
 private:


### PR DESCRIPTION
Hi,
the enum change in ClangCheck.cpp seems to be an obstacle form 'clang-format -style=LLVM ...', which I've overseen (it's late here...).
Let me know if you do not like it. I'll recreate the commit then.

-Foka
