### PR TITLE
Osx clang

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,10 @@
 #  2. LLVM_SRC_PATH := /usr/local/opt/llvm
 #  3. LLVM_BUILD_PATH := $(LLVM_SRC_PATH)
 #  4. CXX:=$(LLVM_BUILD_PATH)/bin/clang++
-#  5. PLUGIN_LDFLAGS := -shared 
+#  5. PLUGIN_LDFLAGS := -shared -undefined dynamic_lookup
+#  6. -Wl,--start-group \   changed to  -Wl, \       
+#  7  -Wl,--end-group    changed to  -Wl,
+
 
 # The following variables will likely need to be customized, depending on where
 # and how you built LLVM & Clang. They can be overridden by setting them on the

--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,14 @@
 # This code is in the public domain
 #-------------------------------------------------------------------------------
 
+#  Changes for building against the Homebrew install of llvm on OSX platforms
+#  (provided by b.van straalen  Lawrence Berkeley National Lab)
+#  1. >brew install llvm --with-toolchain
+#  2. LLVM_SRC_PATH := /usr/local/opt/llvm
+#  3. LLVM_BUILD_PATH := $(LLVM_SRC_PATH)
+#  4. CXX:=$(LLVM_BUILD_PATH)/bin/clang++
+#  5. PLUGIN_LDFLAGS := -shared 
+
 # The following variables will likely need to be customized, depending on where
 # and how you built LLVM & Clang. They can be overridden by setting them on the
 # make command line: "make VARNAME=VALUE", etc.


### PR DESCRIPTION
Comment block for users that wish to edit the top level Makefile to run against the Homebrew installation of llvm on OSX platforms.  That should help a bunch of folks :-)  

I also noticed that if you built your llvm with clang and not g++ then the llvm-config driver does not generate legal compiler options for g++.  Something you might want to add to the readme.  ie.  You need to pick g++ as your compiler, or clang++ for the whole exercise.  Perhaps the whole tutorial could switch over to an LLVM world.