### PR TITLE
Fix call to CreateASTDumper

### DIFF
--- a/src_clang/ClangCheck.cpp
+++ b/src_clang/ClangCheck.cpp
@@ -147,8 +147,7 @@ public:
     if (ASTList)
       return clang::CreateASTDeclNodeLister();
     if (ASTDump)
-      return clang::CreateASTDumper(nullptr /*Dump to stdout.*/,
-                                    ASTDumpFilter,
+      return clang::CreateASTDumper(ASTDumpFilter,
                                     /*DumpDecls=*/true,
                                     /*Deserialize=*/false,
                                     /*DumpLookups=*/false);


### PR DESCRIPTION
Thanks for very helpful blog posts and repo!

I found this change necessary vs llvm 6.0, but I don't know what other LLVM versions need.